### PR TITLE
feat: add notification token refresh icon

### DIFF
--- a/lib/core/presentation/widgets/home_appbar.dart
+++ b/lib/core/presentation/widgets/home_appbar.dart
@@ -2,9 +2,57 @@ import 'package:flutter/material.dart';
 import 'package:opennutritracker/core/presentation/widgets/dynamic_ont_logo.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
 import 'package:opennutritracker/generated/l10n.dart';
+import 'package:opennutritracker/services/firebase_messaging_service.dart';
 
-class HomeAppbar extends StatelessWidget implements PreferredSizeWidget {
+class HomeAppbar extends StatefulWidget implements PreferredSizeWidget {
   const HomeAppbar({super.key});
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+
+  @override
+  State<HomeAppbar> createState() => _HomeAppbarState();
+}
+
+class _HomeAppbarState extends State<HomeAppbar> {
+  bool _hasToken = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _checkToken();
+  }
+
+  Future<void> _checkToken() async {
+    final hasToken =
+        await FirebaseMessagingService.instance().hasPushNotificationsToken();
+    if (mounted) {
+      setState(() {
+        _hasToken = hasToken;
+      });
+    }
+  }
+
+  Future<void> _onNotificationPressed() async {
+    if (_hasToken) return;
+    final success = await FirebaseMessagingService.instance()
+        .refreshPushNotificationsToken();
+    if (success) {
+      await _checkToken();
+      if (!_hasToken) {
+        _showError();
+      }
+    } else {
+      _showError();
+    }
+  }
+
+  void _showError() {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(S.of(context).notificationActivationError)),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -30,6 +78,19 @@ class HomeAppbar extends StatelessWidget implements PreferredSizeWidget {
       ),
       actions: [
         IconButton(
+          icon: Icon(
+            _hasToken
+                ? Icons.notifications_active_outlined
+                : Icons.notifications_off_outlined,
+            color: Theme.of(context)
+                .colorScheme
+                .onSurface
+                .withAlpha(_hasToken ? 255 : 128),
+          ),
+          tooltip: S.of(context).notificationsLabel,
+          onPressed: _onNotificationPressed,
+        ),
+        IconButton(
           icon: Icon(Icons.settings_outlined,
               color: Theme.of(context).colorScheme.onSurface),
           tooltip: S.of(context).settingsLabel,
@@ -40,7 +101,4 @@ class HomeAppbar extends StatelessWidget implements PreferredSizeWidget {
       ],
     );
   }
-
-  @override
-  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
 }

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -723,6 +723,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsDistanceLabel":
             MessageLookupByLibrary.simpleMessage("Entfernung"),
         "settingsLabel": MessageLookupByLibrary.simpleMessage("Einstellungen"),
+        "notificationsLabel":
+            MessageLookupByLibrary.simpleMessage("Benachrichtigungen"),
+        "notificationActivationError": MessageLookupByLibrary.simpleMessage(
+            "Problem beim Aktivieren der Benachrichtigungen. Bitte später erneut versuchen."),
         "settingsLicensesLabel":
             MessageLookupByLibrary.simpleMessage("Lizenzen"),
         "settingsMassLabel": MessageLookupByLibrary.simpleMessage("Masse"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -711,6 +711,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsImperialLabel":
             MessageLookupByLibrary.simpleMessage("Imperial (lbs, ft, oz)"),
         "settingsLabel": MessageLookupByLibrary.simpleMessage("Settings"),
+        "notificationsLabel":
+            MessageLookupByLibrary.simpleMessage("Notifications"),
+        "notificationActivationError": MessageLookupByLibrary.simpleMessage(
+            "Notification activation problem. Please try again later."),
         "settingsLicensesLabel":
             MessageLookupByLibrary.simpleMessage("Licenses"),
         "settingsMassLabel": MessageLookupByLibrary.simpleMessage("Mass"),

--- a/lib/generated/intl/messages_fr.dart
+++ b/lib/generated/intl/messages_fr.dart
@@ -727,6 +727,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsImperialLabel":
             MessageLookupByLibrary.simpleMessage("Impérial (lbs, ft, oz)"),
         "settingsLabel": MessageLookupByLibrary.simpleMessage("Paramètres"),
+        "notificationsLabel":
+            MessageLookupByLibrary.simpleMessage("Notifications"),
+        "notificationActivationError": MessageLookupByLibrary.simpleMessage(
+            "Problème d'activation des notifications. Veuillez réessayer plus tard."),
         "settingsLicensesLabel":
             MessageLookupByLibrary.simpleMessage("Licences"),
         "settingsMassLabel": MessageLookupByLibrary.simpleMessage("Masse"),

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -699,6 +699,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsImperialLabel":
             MessageLookupByLibrary.simpleMessage("İmperial (lbs, ft, oz)"),
         "settingsLabel": MessageLookupByLibrary.simpleMessage("Ayarlar"),
+        "notificationsLabel":
+            MessageLookupByLibrary.simpleMessage("Bildirimler"),
+        "notificationActivationError": MessageLookupByLibrary.simpleMessage(
+            "Bildirim etkinleştirme sorunu. Lütfen daha sonra tekrar deneyin."),
         "settingsLicensesLabel":
             MessageLookupByLibrary.simpleMessage("Lisanslar"),
         "settingsMassLabel": MessageLookupByLibrary.simpleMessage("Kütle"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -161,6 +161,26 @@ class S {
     );
   }
 
+  /// `Notifications`
+  String get notificationsLabel {
+    return Intl.message(
+      'Notifications',
+      name: 'notificationsLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Notification activation problem. Please try again later.`
+  String get notificationActivationError {
+    return Intl.message(
+      'Notification activation problem. Please try again later.',
+      name: 'notificationActivationError',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `Home`
   String get homeLabel {
     return Intl.message(

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -9,6 +9,8 @@
   "createCustomDialogTitle": "Benutzerdefinierte Mahlzeit erstellen?",
   "createCustomDialogContent": "Möchten Sie einen benutzerdefinierte Mahlzeit erstellen?",
   "settingsLabel": "Einstellungen",
+  "notificationsLabel": "Benachrichtigungen",
+  "notificationActivationError": "Problem beim Aktivieren der Benachrichtigungen. Bitte später erneut versuchen.",
   "homeLabel": "Startseite",
   "deltaWeightLabel": "Gewichtsdifferenz",
   "deltaWeightBody": "Die Gewichtsdifferenz ist die Differenz zwischen dem Durchschnittsgewicht und dem für diesen Tag eingegebenen aktuellen Gewicht.\nWenn für den aktuellen Tag kein Gewicht erfasst ist, wird das letzte gültige Gewicht verwendet.",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -13,6 +13,8 @@
   "createCustomDialogTitle": "Create custom meal item?",
   "createCustomDialogContent": "Do you want create a custom meal item?",
   "settingsLabel": "Settings",
+  "notificationsLabel": "Notifications",
+  "notificationActivationError": "Notification activation problem. Please try again later.",
   "homeLabel": "Home",
   "deltaWeightLabel": "Weight Delta",
   "deltaWeightBody": "The weight delta is the difference between the average weight and the current weight entered for this day.\nIf no weight is recorded for the current day, the last valid weight will be used.",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -13,6 +13,8 @@
   "createCustomDialogTitle": "Créer un aliment personnalisé ?",
   "createCustomDialogContent": "Voulez-vous créer un aliment personnalisé ?",
   "settingsLabel": "Paramètres",
+  "notificationsLabel": "Notifications",
+  "notificationActivationError": "Problème d'activation des notifications. Veuillez réessayer plus tard.",
   "homeLabel": "Accueil",
   "deltaWeightLabel": "Écart de poids",
   "deltaWeightBody": "L'écart de poids est la différence entre le poids moyen et le poids courant renseigné pour ce jour.\nSi aucun poids n'est enregistré pour le jour courant, le dernier poids valide sera utilisé.",

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -8,6 +8,8 @@
   "createCustomDialogTitle": "Özel yemek öğesi oluştur?",
   "createCustomDialogContent": "Özel bir yemek öğesi oluşturmak istiyor musunuz?",
   "settingsLabel": "Ayarlar",
+  "notificationsLabel": "Bildirimler",
+  "notificationActivationError": "Bildirim etkinleştirme sorunu. Lütfen daha sonra tekrar deneyin.",
   "homeLabel": "Ana Sayfa",
   "deltaWeightLabel": "Kilo Farkı",
   "deltaWeightBody": "Ağırlık farkı, ortalama ağırlık ile bu gün için girilen mevcut ağırlık arasındaki farktır.\nMevcut gün için herhangi bir ağırlık kaydedilmemişse, son geçerli ağırlık kullanılacaktır.",


### PR DESCRIPTION
## Summary
- show notification icon in home app bar reflecting FCM token presence
- allow retrying FCM token registration
- localize notification labels

## Testing
- `flutter pub get`
- `flutter analyze --no-pub` *(fails: 12142 issues found)*
- `flutter test` *(fails: version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a03bf893b4832195e3756dee0be2bd