### PR TITLE
feat: track burned calories per day

### DIFF
--- a/lib/core/data/data_source/tracked_day_data_source.dart
+++ b/lib/core/data/data_source/tracked_day_data_source.dart
@@ -95,6 +95,28 @@ class TrackedDayDataSource {
     }
   }
 
+  Future<void> addDayCaloriesBurned(DateTime day, double addCalories) async {
+    log.fine('Adding new burned calories');
+    final updateDay = await getTrackedDay(day);
+
+    if (updateDay != null) {
+      updateDay.caloriesBurned += addCalories;
+      await updateDay.save();
+    }
+  }
+
+  Future<void> decreaseDayCaloriesBurned(
+      DateTime day, double subtractCalories) async {
+    log.fine('Decreasing burned calories');
+    final updateDay = await getTrackedDay(day);
+
+    if (updateDay != null) {
+      final newValue = updateDay.caloriesBurned - subtractCalories;
+      updateDay.caloriesBurned = math.max(0, newValue);
+      await updateDay.save();
+    }
+  }
+
   Future<void> updateDayMacroGoals(DateTime day,
       {double? carbsGoal, double? fatGoal, double? proteinGoal}) async {
     log.fine('Updating tracked day macro goals');

--- a/lib/core/data/dbo/tracked_day_dbo.dart
+++ b/lib/core/data/dbo/tracked_day_dbo.dart
@@ -33,6 +33,9 @@ class TrackedDayDBO extends HiveObject {
   @JsonKey(name: 'updated_at')
   DateTime updatedAt;
 
+  @HiveField(10)
+  double caloriesBurned;
+
   TrackedDayDBO(
       {required this.day,
       required this.calorieGoal,
@@ -43,6 +46,7 @@ class TrackedDayDBO extends HiveObject {
       this.fatTracked,
       this.proteinGoal,
       this.proteinTracked,
+      this.caloriesBurned = 0,
       required this.updatedAt});
 
   factory TrackedDayDBO.fromTrackedDayEntity(TrackedDayEntity entity) {
@@ -56,6 +60,7 @@ class TrackedDayDBO extends HiveObject {
         fatTracked: entity.fatTracked,
         proteinGoal: entity.proteinGoal,
         proteinTracked: entity.proteinTracked,
+        caloriesBurned: entity.caloriesBurned,
         updatedAt: entity.updatedAt);
   }
 

--- a/lib/core/data/dbo/tracked_day_dbo.g.dart
+++ b/lib/core/data/dbo/tracked_day_dbo.g.dart
@@ -27,13 +27,14 @@ class TrackedDayDBOAdapter extends TypeAdapter<TrackedDayDBO> {
       proteinGoal: fields[7] as double?,
       proteinTracked: fields[8] as double?,
       updatedAt: fields[9] as DateTime,
+      caloriesBurned: (fields[10] as double?) ?? 0,
     );
   }
 
   @override
   void write(BinaryWriter writer, TrackedDayDBO obj) {
     writer
-      ..writeByte(10)
+      ..writeByte(11)
       ..writeByte(0)
       ..write(obj.day)
       ..writeByte(1)
@@ -53,7 +54,9 @@ class TrackedDayDBOAdapter extends TypeAdapter<TrackedDayDBO> {
       ..writeByte(8)
       ..write(obj.proteinTracked)
       ..writeByte(9)
-      ..write(obj.updatedAt);
+      ..write(obj.updatedAt)
+      ..writeByte(10)
+      ..write(obj.caloriesBurned);
   }
 
   @override
@@ -82,6 +85,7 @@ TrackedDayDBO _$TrackedDayDBOFromJson(Map<String, dynamic> json) =>
       fatTracked: (json['fatTracked'] as num?)?.toDouble(),
       proteinGoal: (json['proteinGoal'] as num?)?.toDouble(),
       proteinTracked: (json['proteinTracked'] as num?)?.toDouble(),
+      caloriesBurned: (json['caloriesBurned'] as num?)?.toDouble() ?? 0,
       updatedAt: DateTime.parse(json['updated_at'] as String),
     );
 
@@ -96,5 +100,6 @@ Map<String, dynamic> _$TrackedDayDBOToJson(TrackedDayDBO instance) =>
       'fatTracked': instance.fatTracked,
       'proteinGoal': instance.proteinGoal,
       'proteinTracked': instance.proteinTracked,
+      'caloriesBurned': instance.caloriesBurned,
       'updated_at': instance.updatedAt.toIso8601String(),
     };

--- a/lib/core/data/repository/tracked_day_repository.dart
+++ b/lib/core/data/repository/tracked_day_repository.dart
@@ -73,6 +73,7 @@ class TrackedDayRepository {
         fatTracked: 0,
         proteinGoal: totalProteinGoal,
         proteinTracked: 0,
+        caloriesBurned: 0,
         updatedAt: DateTime.now().toUtc(),
       ),
     );
@@ -95,6 +96,14 @@ class TrackedDayRepository {
     if (await _trackedDayDataSource.hasTrackedDay(day)) {
       await _trackedDayDataSource.decreaseDayCaloriesTracked(day, addCalories);
     }
+  }
+
+  Future<void> addDayCaloriesBurned(DateTime day, double calories) async {
+    await _trackedDayDataSource.addDayCaloriesBurned(day, calories);
+  }
+
+  Future<void> removeDayCaloriesBurned(DateTime day, double calories) async {
+    await _trackedDayDataSource.decreaseDayCaloriesBurned(day, calories);
   }
 
   Future<void> updateDayMacroGoal(

--- a/lib/core/domain/entity/tracked_day_entity.dart
+++ b/lib/core/domain/entity/tracked_day_entity.dart
@@ -9,6 +9,7 @@ class TrackedDayEntity extends Equatable {
   final DateTime day;
   final double calorieGoal;
   final double caloriesTracked;
+  final double caloriesBurned;
   final double? carbsGoal;
   final double? carbsTracked;
   final double? fatGoal;
@@ -21,6 +22,7 @@ class TrackedDayEntity extends Equatable {
     required this.day,
     required this.calorieGoal,
     required this.caloriesTracked,
+    this.caloriesBurned = 0,
     this.carbsGoal,
     this.carbsTracked,
     this.fatGoal,
@@ -35,6 +37,7 @@ class TrackedDayEntity extends Equatable {
       day: trackedDayDBO.day,
       calorieGoal: trackedDayDBO.calorieGoal,
       caloriesTracked: trackedDayDBO.caloriesTracked,
+      caloriesBurned: trackedDayDBO.caloriesBurned,
       carbsGoal: trackedDayDBO.carbsGoal,
       carbsTracked: trackedDayDBO.carbsTracked,
       fatGoal: trackedDayDBO.fatGoal,
@@ -85,6 +88,7 @@ class TrackedDayEntity extends Equatable {
     day,
     calorieGoal,
     caloriesTracked,
+    caloriesBurned,
     carbsGoal,
     carbsTracked,
     fatGoal,

--- a/lib/core/domain/usecase/add_tracked_day_usecase.dart
+++ b/lib/core/domain/usecase/add_tracked_day_usecase.dart
@@ -41,6 +41,14 @@ class AddTrackedDayUsecase {
     await _trackedDayRepository.removeDayTrackedCalories(day, caloriesTracked);
   }
 
+  Future<void> addDayCaloriesBurned(DateTime day, double calories) async {
+    await _trackedDayRepository.addDayCaloriesBurned(day, calories);
+  }
+
+  Future<void> removeDayCaloriesBurned(DateTime day, double calories) async {
+    await _trackedDayRepository.removeDayCaloriesBurned(day, calories);
+  }
+
   Future<void> updateDayMacroGoals(DateTime day,
       {double? carbsGoal, double? fatGoal, double? proteinGoal}) async {
     await _trackedDayRepository.updateDayMacroGoal(day,

--- a/lib/features/activity_detail/presentation/bloc/activity_detail_bloc.dart
+++ b/lib/features/activity_detail/presentation/bloc/activity_detail_bloc.dart
@@ -112,5 +112,6 @@ class ActivityDetailBloc
       fatAmount: fatIncrease,
       proteinAmount: proteinIncrease,
     );
+    await _addTrackedDayUsecase.addDayCaloriesBurned(day, caloriesBurned);
   }
 }

--- a/lib/features/diary/presentation/bloc/calendar_day_bloc.dart
+++ b/lib/features/diary/presentation/bloc/calendar_day_bloc.dart
@@ -106,6 +106,8 @@ class CalendarDayBloc extends Bloc<CalendarDayEvent, CalendarDayState> {
         carbsAmount: carbsAmount,
         fatAmount: fatAmount,
         proteinAmount: proteinAmount);
+    await _addTrackedDayUsecase.removeDayCaloriesBurned(
+        day, activityEntity.burnedKcal);
     _updateDiaryPage(day);
   }
 

--- a/lib/features/home/presentation/bloc/home_bloc.dart
+++ b/lib/features/home/presentation/bloc/home_bloc.dart
@@ -218,6 +218,8 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
         carbsAmount: carbsAmount,
         fatAmount: fatAmount,
         proteinAmount: proteinAmount);
+    await _addTrackedDayUseCase.removeDayCaloriesBurned(
+        dateTime, activityEntity.burnedKcal);
     _updateDiaryPage(dateTime);
   }
 


### PR DESCRIPTION
## Summary
- add caloriesBurned field to tracked day records
- update activity flows to maintain burned calorie totals and sync to Supabase

## Testing
- `flutter pub get`
- `flutter analyze` *(fails: version solving failed for analyzer/macro packages)*
- `flutter test` *(fails: version solving failed for analyzer/macro packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a08fe0c4e08321858137066fe91174