### PR TITLE
Move logout option to settings

### DIFF
--- a/lib/features/auth/forgot_password_screen.dart
+++ b/lib/features/auth/forgot_password_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/gestures.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
 import 'package:email_validator/email_validator.dart';
 import 'package:opennutritracker/generated/l10n.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class ForgotPasswordScreen extends StatefulWidget {
   const ForgotPasswordScreen({super.key});
@@ -42,8 +44,7 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
         ),
       );
 
-      // 👉 no more push to ResetPasswordScreen here
-      Navigator.of(context).pop(); // or pushNamed(loginRoute)
+      Navigator.of(context).pop();
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
@@ -65,6 +66,50 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
+              Card(
+                color: Colors.amber.shade100,
+                elevation: 0,
+                margin: const EdgeInsets.only(bottom: 16),
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: RichText(
+                          text: TextSpan(
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyMedium
+                                ?.copyWith(color: Colors.black87),
+                          children: [
+                              TextSpan(
+                                text: S.of(context).forgotPasswordHelp,
+                              ),
+                              TextSpan(
+                                text: S.of(context).websiteLabel,
+                                style: const TextStyle(
+                                  decoration: TextDecoration.underline,
+                                ),
+                                recognizer: TapGestureRecognizer()
+                                  ..onTap = () async {
+                                    final url = Uri.parse(
+                                        "https://atlas-tracker.fr/auth/forgot-password");
+                                    if (await canLaunchUrl(url)) {
+                                      await launchUrl(url,
+                                          mode: LaunchMode.externalApplication);
+                                    }
+                                  },
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
               TextFormField(
                 controller: _emailCtrl,
                 keyboardType: TextInputType.emailAddress,
@@ -99,8 +144,8 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
                 child: TextButton(
                   onPressed: () =>
                       Navigator.of(context).pushNamedAndRemoveUntil(
-                    NavigationOptions.loginRoute, // your login route
-                    (route) => false, // remove everything else from the stack
+                    NavigationOptions.loginRoute,
+                    (route) => false,
                   ),
                   child: Text(S.of(context).forgotPasswordBackToLogin),
                 ),

--- a/lib/features/profile/profile_page.dart
+++ b/lib/features/profile/profile_page.dart
@@ -16,7 +16,6 @@ import 'package:opennutritracker/features/profile/presentation/widgets/set_pal_c
 import 'package:opennutritracker/features/profile/presentation/widgets/set_weight_dialog.dart';
 import 'package:opennutritracker/features/profile/presentation/widgets/profile_photo_picker.dart';
 import 'package:opennutritracker/generated/l10n.dart';
-import 'package:opennutritracker/features/auth/auth_safe_sign_out.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'coach_students_page.dart';
 import 'presentation/widgets/manage_account_dialog.dart';
@@ -236,14 +235,6 @@ class _ProfilePageState extends State<ProfilePage> {
             context: context,
             builder: (_) => const ManageAccountDialog(),
           ),
-        ),
-        ListTile(
-          leading: const SizedBox(
-            height: double.infinity,
-            child: Icon(Icons.logout),
-          ),
-          title: const Text('Log out'),
-          onTap: () => safeSignOut(context),
         ),
         const SizedBox(height: 12),
       ],

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -100,7 +100,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 ),
                 ListTile(
                   leading: const Icon(Icons.logout),
-                  title: const Text('Log out'),
+                  title: Text(S.of(context).logOutLabel),
                   onTap: () => safeSignOut(context),
                 ),
                 const SizedBox(height: 32.0),

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -12,6 +12,7 @@ import 'package:opennutritracker/features/settings/presentation/bloc/settings_bl
 import 'package:opennutritracker/features/settings/presentation/widgets/export_import_dialog.dart';
 import 'package:opennutritracker/features/settings/presentation/widgets/export_import_supabase_dialog.dart';
 import 'package:opennutritracker/features/settings/presentation/widgets/calculations_dialog.dart';
+import 'package:opennutritracker/features/auth/auth_safe_sign_out.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
@@ -96,6 +97,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   leading: const Icon(Icons.error_outline_outlined),
                   title: Text(S.of(context).settingAboutLabel),
                   onTap: () => _showAboutDialog(context),
+                ),
+                ListTile(
+                  leading: const Icon(Icons.logout),
+                  title: const Text('Log out'),
+                  onTap: () => safeSignOut(context),
                 ),
                 const SizedBox(height: 32.0),
                 AppBannerVersion(versionNumber: state.versionNumber),

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -755,6 +755,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "suppliedLabel": MessageLookupByLibrary.simpleMessage("zugeführt"),
         "unitLabel": MessageLookupByLibrary.simpleMessage("Einheit"),
         "weightLabel": MessageLookupByLibrary.simpleMessage("Gewicht"),
-        "yearsLabel": m3
+        "yearsLabel": m3,
+        "logOutLabel": MessageLookupByLibrary.simpleMessage("Abmelden"),
+        "forgotPasswordHelp": MessageLookupByLibrary.simpleMessage("Wenn das Zurücksetzen des Passworts nicht funktioniert:\n- Beenden Sie die App und versuchen Sie es erneut, oder\n- stellen Sie die Anfrage über die Website: "),
+        "websiteLabel": MessageLookupByLibrary.simpleMessage("Website")
       };
 }

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -746,6 +746,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "suppliedLabel": MessageLookupByLibrary.simpleMessage("supplied"),
         "unitLabel": MessageLookupByLibrary.simpleMessage("Unit"),
         "weightLabel": MessageLookupByLibrary.simpleMessage("Weight"),
-        "yearsLabel": m3
+        "yearsLabel": m3,
+        "logOutLabel": MessageLookupByLibrary.simpleMessage("Log out"),
+        "forgotPasswordHelp": MessageLookupByLibrary.simpleMessage("If the password reset doesn't work:\n- exit the app and try again, or\n- make the request from the website: "),
+        "websiteLabel": MessageLookupByLibrary.simpleMessage("website")
       };
 }

--- a/lib/generated/intl/messages_fr.dart
+++ b/lib/generated/intl/messages_fr.dart
@@ -762,6 +762,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "suppliedLabel": MessageLookupByLibrary.simpleMessage("Ingérées"),
         "unitLabel": MessageLookupByLibrary.simpleMessage("Unité"),
         "weightLabel": MessageLookupByLibrary.simpleMessage("Poids"),
-        "yearsLabel": m3
+        "yearsLabel": m3,
+        "logOutLabel": MessageLookupByLibrary.simpleMessage("Se déconnecter"),
+        "forgotPasswordHelp": MessageLookupByLibrary.simpleMessage("Si le reset de mot de passe ne fonctionne pas :\n- quitter l'application et recommencer la manipulation, ou\n- faire la demande depuis le site : "),
+        "websiteLabel": MessageLookupByLibrary.simpleMessage("site")
       };
 }

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -733,6 +733,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "suppliedLabel": MessageLookupByLibrary.simpleMessage("tüketilen"),
         "unitLabel": MessageLookupByLibrary.simpleMessage("Birim"),
         "weightLabel": MessageLookupByLibrary.simpleMessage("Kilo"),
-        "yearsLabel": m3
+        "yearsLabel": m3,
+        "logOutLabel": MessageLookupByLibrary.simpleMessage("Çıkış yap"),
+        "forgotPasswordHelp": MessageLookupByLibrary.simpleMessage("Şifre sıfırlama çalışmazsa:\n- uygulamadan çıkıp işlemi tekrar deneyin veya\n- isteği web sitesi üzerinden yapın: "),
+        "websiteLabel": MessageLookupByLibrary.simpleMessage("web sitesi")
       };
 }

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -4631,6 +4631,36 @@ class S {
       args: [],
     );
   }
+
+  /// `Log out`
+  String get logOutLabel {
+    return Intl.message(
+      'Log out',
+      name: 'logOutLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `If the password reset doesn't work:\n- exit the app and try again, or\n- make the request from the website: `
+  String get forgotPasswordHelp {
+    return Intl.message(
+      'If the password reset doesn\'t work:\n- exit the app and try again, or\n- make the request from the website: ',
+      name: 'forgotPasswordHelp',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `website`
+  String get websiteLabel {
+    return Intl.message(
+      'website',
+      name: 'websiteLabel',
+      desc: '',
+      args: [],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -449,6 +449,9 @@
   "manageAccountDelete": "Mein Konto l\u00f6schen",
   "manageAccountConfirmTitle": "Bist du sicher?",
   "manageAccountConfirmMessage": "Dieser Vorgang kann nicht r\u00fcckg\u00e4ngig gemacht werden.",
-  "manageAccountConfirmAction": "L\u00f6schung best\u00e4tigen"
+  "manageAccountConfirmAction": "L\u00f6schung best\u00e4tigen",
+  "logOutLabel": "Abmelden",
+  "forgotPasswordHelp": "Wenn das Zur\u00fccksetzen des Passworts nicht funktioniert:\n- Beenden Sie die App und versuchen Sie es erneut, oder\n- stellen Sie die Anfrage \u00fcber die Website: ",
+  "websiteLabel": "Website"
 }
 

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -462,5 +462,8 @@
   "manageAccountDelete": "Delete My Account",
   "manageAccountConfirmTitle": "Are you sure?",
   "manageAccountConfirmMessage": "This action cannot be undone.",
-  "manageAccountConfirmAction": "Confirm Deletion"
+  "manageAccountConfirmAction": "Confirm Deletion",
+  "logOutLabel": "Log out",
+  "forgotPasswordHelp": "If the password reset doesn't work:\n- exit the app and try again, or\n- make the request from the website: ",
+  "websiteLabel": "website"
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -460,6 +460,9 @@
   "manageAccountDelete": "Supprimer mon compte",
   "manageAccountConfirmTitle": "Êtes-vous sûr ?",
   "manageAccountConfirmMessage": "Cette action est irréversible.",
-  "manageAccountConfirmAction": "Confirmer la suppression"
+  "manageAccountConfirmAction": "Confirmer la suppression",
+  "logOutLabel": "Se déconnecter",
+  "forgotPasswordHelp": "Si le reset de mot de passe ne fonctionne pas :\n- quitter l'application et recommencer la manipulation, ou\n- faire la demande depuis le site : ",
+  "websiteLabel": "site"
 }
 

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -454,5 +454,8 @@
   "manageAccountDelete": "Hesabımı Sil",
   "manageAccountConfirmTitle": "Emin misiniz?",
   "manageAccountConfirmMessage": "Bu işlem geri alınamaz.",
-  "manageAccountConfirmAction": "Silmeyi Onayla"
+  "manageAccountConfirmAction": "Silmeyi Onayla",
+  "logOutLabel": "Çıkış yap",
+  "forgotPasswordHelp": "Şifre sıfırlama çalışmazsa:\n- uygulamadan çıkıp işlemi tekrar deneyin veya\n- isteği web sitesi üzerinden yapın: ",
+  "websiteLabel": "web sitesi"
 }


### PR DESCRIPTION
## Summary
- relocate log out from profile page to settings screen
- clean up profile page imports

## Testing
- `flutter pub get` *(fails: It appears that the downloaded file is corrupt; please try again.)*
- `flutter analyze` *(fails: It appears that the downloaded file is corrupt; please try again.)*
- `flutter test` *(fails: It appears that the downloaded file is corrupt; please try again.)*

------
https://chatgpt.com/codex/tasks/task_e_68a09128a5b88321a5105d4285717de9