### PR TITLE
Localize logout text and password reset help

### DIFF
--- a/lib/features/auth/forgot_password_screen.dart
+++ b/lib/features/auth/forgot_password_screen.dart
@@ -83,15 +83,12 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
                                 .textTheme
                                 .bodyMedium
                                 ?.copyWith(color: Colors.black87),
-                            children: [
-                              const TextSpan(
-                                text:
-                                    "Si le reset de mot de passe ne fonctionne pas :\n"
-                                    "- quitter l'application et recommencer la manipulation, ou\n"
-                                    "- faire la demande depuis le site : ",
+                          children: [
+                              TextSpan(
+                                text: S.of(context).forgotPasswordHelp,
                               ),
                               TextSpan(
-                                text: "website",
+                                text: S.of(context).websiteLabel,
                                 style: const TextStyle(
                                   decoration: TextDecoration.underline,
                                 ),

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -100,7 +100,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 ),
                 ListTile(
                   leading: const Icon(Icons.logout),
-                  title: const Text('Log out'),
+                  title: Text(S.of(context).logOutLabel),
                   onTap: () => safeSignOut(context),
                 ),
                 const SizedBox(height: 32.0),

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -755,6 +755,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "suppliedLabel": MessageLookupByLibrary.simpleMessage("zugeführt"),
         "unitLabel": MessageLookupByLibrary.simpleMessage("Einheit"),
         "weightLabel": MessageLookupByLibrary.simpleMessage("Gewicht"),
-        "yearsLabel": m3
+        "yearsLabel": m3,
+        "logOutLabel": MessageLookupByLibrary.simpleMessage("Abmelden"),
+        "forgotPasswordHelp": MessageLookupByLibrary.simpleMessage("Wenn das Zurücksetzen des Passworts nicht funktioniert:\n- Beenden Sie die App und versuchen Sie es erneut, oder\n- stellen Sie die Anfrage über die Website: "),
+        "websiteLabel": MessageLookupByLibrary.simpleMessage("Website")
       };
 }

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -746,6 +746,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "suppliedLabel": MessageLookupByLibrary.simpleMessage("supplied"),
         "unitLabel": MessageLookupByLibrary.simpleMessage("Unit"),
         "weightLabel": MessageLookupByLibrary.simpleMessage("Weight"),
-        "yearsLabel": m3
+        "yearsLabel": m3,
+        "logOutLabel": MessageLookupByLibrary.simpleMessage("Log out"),
+        "forgotPasswordHelp": MessageLookupByLibrary.simpleMessage("If the password reset doesn't work:\n- exit the app and try again, or\n- make the request from the website: "),
+        "websiteLabel": MessageLookupByLibrary.simpleMessage("website")
       };
 }

--- a/lib/generated/intl/messages_fr.dart
+++ b/lib/generated/intl/messages_fr.dart
@@ -762,6 +762,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "suppliedLabel": MessageLookupByLibrary.simpleMessage("Ingérées"),
         "unitLabel": MessageLookupByLibrary.simpleMessage("Unité"),
         "weightLabel": MessageLookupByLibrary.simpleMessage("Poids"),
-        "yearsLabel": m3
+        "yearsLabel": m3,
+        "logOutLabel": MessageLookupByLibrary.simpleMessage("Se déconnecter"),
+        "forgotPasswordHelp": MessageLookupByLibrary.simpleMessage("Si le reset de mot de passe ne fonctionne pas :\n- quitter l'application et recommencer la manipulation, ou\n- faire la demande depuis le site : "),
+        "websiteLabel": MessageLookupByLibrary.simpleMessage("site")
       };
 }

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -733,6 +733,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "suppliedLabel": MessageLookupByLibrary.simpleMessage("tüketilen"),
         "unitLabel": MessageLookupByLibrary.simpleMessage("Birim"),
         "weightLabel": MessageLookupByLibrary.simpleMessage("Kilo"),
-        "yearsLabel": m3
+        "yearsLabel": m3,
+        "logOutLabel": MessageLookupByLibrary.simpleMessage("Çıkış yap"),
+        "forgotPasswordHelp": MessageLookupByLibrary.simpleMessage("Şifre sıfırlama çalışmazsa:\n- uygulamadan çıkıp işlemi tekrar deneyin veya\n- isteği web sitesi üzerinden yapın: "),
+        "websiteLabel": MessageLookupByLibrary.simpleMessage("web sitesi")
       };
 }

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -4631,6 +4631,36 @@ class S {
       args: [],
     );
   }
+
+  /// `Log out`
+  String get logOutLabel {
+    return Intl.message(
+      'Log out',
+      name: 'logOutLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `If the password reset doesn't work:\n- exit the app and try again, or\n- make the request from the website: `
+  String get forgotPasswordHelp {
+    return Intl.message(
+      'If the password reset doesn\'t work:\n- exit the app and try again, or\n- make the request from the website: ',
+      name: 'forgotPasswordHelp',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `website`
+  String get websiteLabel {
+    return Intl.message(
+      'website',
+      name: 'websiteLabel',
+      desc: '',
+      args: [],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -449,6 +449,9 @@
   "manageAccountDelete": "Mein Konto l\u00f6schen",
   "manageAccountConfirmTitle": "Bist du sicher?",
   "manageAccountConfirmMessage": "Dieser Vorgang kann nicht r\u00fcckg\u00e4ngig gemacht werden.",
-  "manageAccountConfirmAction": "L\u00f6schung best\u00e4tigen"
+  "manageAccountConfirmAction": "L\u00f6schung best\u00e4tigen",
+  "logOutLabel": "Abmelden",
+  "forgotPasswordHelp": "Wenn das Zur\u00fccksetzen des Passworts nicht funktioniert:\n- Beenden Sie die App und versuchen Sie es erneut, oder\n- stellen Sie die Anfrage \u00fcber die Website: ",
+  "websiteLabel": "Website"
 }
 

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -462,5 +462,8 @@
   "manageAccountDelete": "Delete My Account",
   "manageAccountConfirmTitle": "Are you sure?",
   "manageAccountConfirmMessage": "This action cannot be undone.",
-  "manageAccountConfirmAction": "Confirm Deletion"
+  "manageAccountConfirmAction": "Confirm Deletion",
+  "logOutLabel": "Log out",
+  "forgotPasswordHelp": "If the password reset doesn't work:\n- exit the app and try again, or\n- make the request from the website: ",
+  "websiteLabel": "website"
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -460,6 +460,9 @@
   "manageAccountDelete": "Supprimer mon compte",
   "manageAccountConfirmTitle": "Êtes-vous sûr ?",
   "manageAccountConfirmMessage": "Cette action est irréversible.",
-  "manageAccountConfirmAction": "Confirmer la suppression"
+  "manageAccountConfirmAction": "Confirmer la suppression",
+  "logOutLabel": "Se déconnecter",
+  "forgotPasswordHelp": "Si le reset de mot de passe ne fonctionne pas :\n- quitter l'application et recommencer la manipulation, ou\n- faire la demande depuis le site : ",
+  "websiteLabel": "site"
 }
 

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -454,5 +454,8 @@
   "manageAccountDelete": "Hesabımı Sil",
   "manageAccountConfirmTitle": "Emin misiniz?",
   "manageAccountConfirmMessage": "Bu işlem geri alınamaz.",
-  "manageAccountConfirmAction": "Silmeyi Onayla"
+  "manageAccountConfirmAction": "Silmeyi Onayla",
+  "logOutLabel": "Çıkış yap",
+  "forgotPasswordHelp": "Şifre sıfırlama çalışmazsa:\n- uygulamadan çıkıp işlemi tekrar deneyin veya\n- isteği web sitesi üzerinden yapın: ",
+  "websiteLabel": "web sitesi"
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded logout text with localized string
- Localize password reset help text and link label
- Add translations for new strings in all localization files

## Testing
- `flutter pub get` *(fails: analyzer ^6.11.0 requires unavailable macros)*
- `flutter analyze` *(fails: analyzer ^6.11.0 requires unavailable macros)*
- `flutter test` *(fails: analyzer ^6.11.0 requires unavailable macros)*

------
https://chatgpt.com/codex/tasks/task_e_68a195bf56a48321a84f989d4c3726c0