### PR TITLE
Use daily macro data in student macros page

### DIFF
--- a/lib/features/profile/presentation/bloc/student_macros_bloc.dart
+++ b/lib/features/profile/presentation/bloc/student_macros_bloc.dart
@@ -1,0 +1,128 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+part 'student_macros_event.dart';
+part 'student_macros_state.dart';
+
+enum MacroType { calories, carbs, fat, protein, weight }
+
+enum TimeRange { week, month, threeMonths, sixMonths, year }
+
+class StudentMacrosBloc extends Bloc<StudentMacrosEvent, StudentMacrosState> {
+  final SupabaseClient _supabase;
+
+  StudentMacrosBloc(this._supabase) : super(StudentMacrosInitial()) {
+    on<LoadStudentMacrosEvent>(_onLoad);
+    on<ChangeDateEvent>(_onChangeDate);
+    on<ChangeMacroTypeEvent>(_onChangeMacro);
+    on<ChangeRangeEvent>(_onChangeRange);
+    on<UpdateDayMacrosEvent>(_onUpdateDayMacros);
+  }
+
+  Future<void> _onLoad(
+    LoadStudentMacrosEvent event,
+    Emitter<StudentMacrosState> emit,
+  ) async {
+    emit(StudentMacrosLoading());
+    try {
+      final macros = await _fetchMacros(event.studentId);
+      emit(
+        StudentMacrosLoaded(
+          macros: macros,
+          selectedDate: DateTime.now(),
+          selectedMacro: MacroType.calories,
+          selectedRange: TimeRange.month,
+        ),
+      );
+    } catch (e) {
+      emit(StudentMacrosError(e.toString()));
+    }
+  }
+
+  void _onChangeDate(
+    ChangeDateEvent event,
+    Emitter<StudentMacrosState> emit,
+  ) {
+    final current = state;
+    if (current is StudentMacrosLoaded) {
+      emit(current.copyWith(selectedDate: event.date));
+    }
+  }
+
+  void _onChangeMacro(
+    ChangeMacroTypeEvent event,
+    Emitter<StudentMacrosState> emit,
+  ) {
+    final current = state;
+    if (current is StudentMacrosLoaded) {
+      emit(current.copyWith(selectedMacro: event.macro));
+    }
+  }
+
+  void _onChangeRange(
+    ChangeRangeEvent event,
+    Emitter<StudentMacrosState> emit,
+  ) {
+    final current = state;
+    if (current is StudentMacrosLoaded) {
+      emit(current.copyWith(selectedRange: event.range));
+    }
+  }
+
+  void _onUpdateDayMacros(
+    UpdateDayMacrosEvent event,
+    Emitter<StudentMacrosState> emit,
+  ) {
+    final current = state;
+    if (current is StudentMacrosLoaded) {
+      final newMacros = Map<String, Map<String, dynamic>>.from(current.macros);
+      final existing = Map<String, dynamic>.from(newMacros[event.dayKey] ?? {});
+      existing.addAll(event.data);
+      newMacros[event.dayKey] = existing;
+      emit(current.copyWith(macros: newMacros));
+    }
+  }
+
+  Future<Map<String, Map<String, dynamic>>> _fetchMacros(
+    String studentId,
+  ) async {
+    final now = DateTime.now();
+    final startDate = DateFormat('yyyy-MM-dd')
+        .format(now.subtract(const Duration(days: 365)));
+    final endDate = DateFormat('yyyy-MM-dd').format(now);
+
+    final macroResponse = await _supabase
+        .from('tracked_days')
+        .select(
+          'day, calorieGoal, caloriesTracked, caloriesBurned, carbsGoal, carbsTracked, fatGoal, fatTracked, proteinGoal, proteinTracked',
+        )
+        .eq('user_id', studentId)
+        .gte('day', startDate)
+        .lte('day', endDate)
+        .order('day');
+
+    final weightResponse = await _supabase
+        .from('user_weight')
+        .select('date, weight')
+        .eq('user_id', studentId)
+        .gte('date', startDate)
+        .lte('date', endDate)
+        .order('date');
+
+    final Map<String, Map<String, dynamic>> result = {
+      for (final Map<String, dynamic> item in macroResponse)
+        item['day'] as String: item,
+    };
+
+    for (final Map<String, dynamic> item in weightResponse) {
+      final dateStr = item['date'] as String;
+      result.putIfAbsent(dateStr, () => {});
+      result[dateStr]!['weight'] = item['weight'];
+    }
+
+    return result;
+  }
+}
+

--- a/lib/features/profile/presentation/bloc/student_macros_event.dart
+++ b/lib/features/profile/presentation/bloc/student_macros_event.dart
@@ -1,0 +1,43 @@
+part of 'student_macros_bloc.dart';
+
+abstract class StudentMacrosEvent extends Equatable {
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadStudentMacrosEvent extends StudentMacrosEvent {
+  final String studentId;
+  LoadStudentMacrosEvent(this.studentId);
+  @override
+  List<Object?> get props => [studentId];
+}
+
+class ChangeDateEvent extends StudentMacrosEvent {
+  final DateTime date;
+  ChangeDateEvent(this.date);
+  @override
+  List<Object?> get props => [date];
+}
+
+class ChangeMacroTypeEvent extends StudentMacrosEvent {
+  final MacroType macro;
+  ChangeMacroTypeEvent(this.macro);
+  @override
+  List<Object?> get props => [macro];
+}
+
+class ChangeRangeEvent extends StudentMacrosEvent {
+  final TimeRange range;
+  ChangeRangeEvent(this.range);
+  @override
+  List<Object?> get props => [range];
+}
+
+class UpdateDayMacrosEvent extends StudentMacrosEvent {
+  final String dayKey;
+  final Map<String, dynamic> data;
+  UpdateDayMacrosEvent(this.dayKey, this.data);
+  @override
+  List<Object?> get props => [dayKey, data];
+}
+

--- a/lib/features/profile/presentation/bloc/student_macros_state.dart
+++ b/lib/features/profile/presentation/bloc/student_macros_state.dart
@@ -1,0 +1,54 @@
+part of 'student_macros_bloc.dart';
+
+abstract class StudentMacrosState extends Equatable {
+  const StudentMacrosState();
+}
+
+class StudentMacrosInitial extends StudentMacrosState {
+  @override
+  List<Object?> get props => [];
+}
+
+class StudentMacrosLoading extends StudentMacrosState {
+  @override
+  List<Object?> get props => [];
+}
+
+class StudentMacrosLoaded extends StudentMacrosState {
+  final Map<String, Map<String, dynamic>> macros;
+  final DateTime selectedDate;
+  final MacroType selectedMacro;
+  final TimeRange selectedRange;
+
+  const StudentMacrosLoaded({
+    required this.macros,
+    required this.selectedDate,
+    required this.selectedMacro,
+    required this.selectedRange,
+  });
+
+  StudentMacrosLoaded copyWith({
+    Map<String, Map<String, dynamic>>? macros,
+    DateTime? selectedDate,
+    MacroType? selectedMacro,
+    TimeRange? selectedRange,
+  }) {
+    return StudentMacrosLoaded(
+      macros: macros ?? this.macros,
+      selectedDate: selectedDate ?? this.selectedDate,
+      selectedMacro: selectedMacro ?? this.selectedMacro,
+      selectedRange: selectedRange ?? this.selectedRange,
+    );
+  }
+
+  @override
+  List<Object?> get props => [macros, selectedDate, selectedMacro, selectedRange];
+}
+
+class StudentMacrosError extends StudentMacrosState {
+  final String message;
+  const StudentMacrosError(this.message);
+  @override
+  List<Object?> get props => [message];
+}
+

--- a/lib/features/profile/student_macros_page.dart
+++ b/lib/features/profile/student_macros_page.dart
@@ -366,6 +366,7 @@ class _StudentMacrosView extends StatelessWidget {
   }
 
   Future<void> _selectDate(BuildContext context, DateTime initial) async {
+    final bloc = context.read<StudentMacrosBloc>();
     final DateTime? picked = await showDatePicker(
       context: context,
       initialDate: initial,
@@ -373,7 +374,7 @@ class _StudentMacrosView extends StatelessWidget {
       lastDate: DateTime.now(),
     );
     if (picked != null) {
-      context.read<StudentMacrosBloc>().add(ChangeDateEvent(picked));
+      bloc.add(ChangeDateEvent(picked));
     }
   }
 

--- a/lib/features/profile/student_macros_page.dart
+++ b/lib/features/profile/student_macros_page.dart
@@ -33,15 +33,6 @@ class _StudentMacrosPageState extends State<StudentMacrosPage> {
   DateTime _selectedDate = DateTime.now();
   MacroType _selectedMacro = MacroType.calories;
   TimeRange _selectedRange = TimeRange.month;
-  double caloriesTracked = 0;
-  double caloriesBurned = 0;
-  double calorieGoal = 0;
-  double carbsGoal = 0;
-  double carbsTracked = 0;
-  double fatGoal = 0;
-  double fatTracked = 0;
-  double proteinGoal = 0;
-  double proteinTracked = 0;
 
   @override
   void initState() {
@@ -68,34 +59,6 @@ class _StudentMacrosPageState extends State<StudentMacrosPage> {
         .gte('day', startDate)
         .lte('day', endDate)
         .order('day');
-
-    caloriesTracked = macroResponse.isNotEmpty
-        ? (macroResponse.last['caloriesTracked'] as num?)?.toDouble() ?? 0
-        : 0;
-    caloriesBurned = macroResponse.isNotEmpty
-        ? (macroResponse.last['caloriesBurned'] as num?)?.toDouble() ?? 0
-        : 0;
-    calorieGoal = macroResponse.isNotEmpty
-        ? (macroResponse.last['calorieGoal'] as num?)?.toDouble() ?? 0
-        : 0;
-    carbsTracked = macroResponse.isNotEmpty
-        ? (macroResponse.last['carbsTracked'] as num?)?.toDouble() ?? 0
-        : 0;
-    carbsGoal = macroResponse.isNotEmpty
-        ? (macroResponse.last['carbsGoal'] as num?)?.toDouble() ?? 0
-        : 0;
-    fatTracked = macroResponse.isNotEmpty
-        ? (macroResponse.last['fatTracked'] as num?)?.toDouble() ?? 0
-        : 0;
-    fatGoal = macroResponse.isNotEmpty
-        ? (macroResponse.last['fatGoal'] as num?)?.toDouble() ?? 0
-        : 0;
-    proteinTracked = macroResponse.isNotEmpty
-        ? (macroResponse.last['proteinTracked'] as num?)?.toDouble() ?? 0
-        : 0;
-    proteinGoal = macroResponse.isNotEmpty
-        ? (macroResponse.last['proteinGoal'] as num?)?.toDouble() ?? 0
-        : 0;
 
     // 2. Récupère les poids
     final weightResponse = await supabase
@@ -149,6 +112,23 @@ class _StudentMacrosPageState extends State<StudentMacrosPage> {
 
           final dayKey = DateFormat('yyyy-MM-dd').format(_selectedDate);
           final data = _allMacros[dayKey];
+          final double calorieGoal =
+              (data?['calorieGoal'] as num?)?.toDouble() ?? 0;
+          final double caloriesTracked =
+              (data?['caloriesTracked'] as num?)?.toDouble() ?? 0;
+          final double caloriesBurned =
+              (data?['caloriesBurned'] as num?)?.toDouble() ?? 0;
+          final double carbsGoal =
+              (data?['carbsGoal'] as num?)?.toDouble() ?? 0;
+          final double carbsTracked =
+              (data?['carbsTracked'] as num?)?.toDouble() ?? 0;
+          final double fatGoal = (data?['fatGoal'] as num?)?.toDouble() ?? 0;
+          final double fatTracked =
+              (data?['fatTracked'] as num?)?.toDouble() ?? 0;
+          final double proteinGoal =
+              (data?['proteinGoal'] as num?)?.toDouble() ?? 0;
+          final double proteinTracked =
+              (data?['proteinTracked'] as num?)?.toDouble() ?? 0;
 
           final double kcalLeft = calorieGoal - caloriesTracked;
           final double gaugeValue = calorieGoal == 0
@@ -205,9 +185,7 @@ class _StudentMacrosPageState extends State<StudentMacrosPage> {
                                 ),
                                 Text(
                                   '${caloriesTracked.toInt()}',
-                                  style: Theme.of(context)
-                                      .textTheme
-                                      .titleLarge
+                                  style: Theme.of(context).textTheme.titleLarge
                                       ?.copyWith(
                                         color: Theme.of(
                                           context,
@@ -216,9 +194,7 @@ class _StudentMacrosPageState extends State<StudentMacrosPage> {
                                 ),
                                 Text(
                                   S.of(context).suppliedLabel,
-                                  style: Theme.of(context)
-                                      .textTheme
-                                      .titleSmall
+                                  style: Theme.of(context).textTheme.titleSmall
                                       ?.copyWith(
                                         color: Theme.of(
                                           context,
@@ -246,8 +222,9 @@ class _StudentMacrosPageState extends State<StudentMacrosPage> {
                                     duration: const Duration(
                                       milliseconds: 1000,
                                     ),
-                                    value:
-                                        kcalLeft.clamp(0, calorieGoal).toInt(),
+                                    value: kcalLeft
+                                        .clamp(0, calorieGoal)
+                                        .toInt(),
                                     textStyle: Theme.of(context)
                                         .textTheme
                                         .headlineMedium
@@ -283,9 +260,7 @@ class _StudentMacrosPageState extends State<StudentMacrosPage> {
                                 ),
                                 Text(
                                   '${caloriesBurned.toInt()}',
-                                  style: Theme.of(context)
-                                      .textTheme
-                                      .titleLarge
+                                  style: Theme.of(context).textTheme.titleLarge
                                       ?.copyWith(
                                         color: Theme.of(
                                           context,
@@ -294,9 +269,7 @@ class _StudentMacrosPageState extends State<StudentMacrosPage> {
                                 ),
                                 Text(
                                   S.of(context).burnedLabel,
-                                  style: Theme.of(context)
-                                      .textTheme
-                                      .titleSmall
+                                  style: Theme.of(context).textTheme.titleSmall
                                       ?.copyWith(
                                         color: Theme.of(
                                           context,
@@ -486,14 +459,16 @@ class _StudentMacrosPageState extends State<StudentMacrosPage> {
   }
 
   Future<void> _openSetMacrosPage() async {
+    final dayKey = DateFormat('yyyy-MM-dd').format(_selectedDate);
+    final data = _allMacros[dayKey];
     final result = await Navigator.push(
       context,
       MaterialPageRoute(
         builder: (_) => SetStudentMacrosPage(
           studentId: widget.studentId,
-          initialCarbs: carbsGoal.toInt(),
-          initialFat: fatGoal.toInt(),
-          initialProtein: proteinGoal.toInt(),
+          initialCarbs: (data?['carbsGoal'] as num?)?.toInt() ?? 0,
+          initialFat: (data?['fatGoal'] as num?)?.toInt() ?? 0,
+          initialProtein: (data?['proteinGoal'] as num?)?.toInt() ?? 0,
         ),
       ),
     );
@@ -513,14 +488,6 @@ class _StudentMacrosPageState extends State<StudentMacrosPage> {
           _allMacros[startDate]!['fatGoal'] = newFat;
           _allMacros[startDate]!['proteinGoal'] = newProtein;
           _allMacros[startDate]!['calorieGoal'] = newCalories;
-
-          final today = DateFormat('yyyy-MM-dd').format(DateTime.now());
-          if (startDate == today) {
-            carbsGoal = newCarbs;
-            fatGoal = newFat;
-            proteinGoal = newProtein;
-            calorieGoal = newCalories;
-          }
         }
       });
     }
@@ -531,9 +498,11 @@ class _StudentMacrosPageState extends State<StudentMacrosPage> {
     final start = _rangeStart(now);
     final List<_MacroPoint> points = [];
 
-    for (var day = start;
-        !day.isAfter(now);
-        day = day.add(const Duration(days: 1))) {
+    for (
+      var day = start;
+      !day.isAfter(now);
+      day = day.add(const Duration(days: 1))
+    ) {
       final normalizedDay = DateTime(
         day.year,
         day.month,


### PR DESCRIPTION
## Summary
- Remove unnecessary macro state fields and derive values from selected day's data
- Pass macros for the chosen day when editing student macros

## Testing
- `flutter pub get`
- `flutter analyze` *(fails: analyzer ^6.11.0 requires _macros 0.3.3)*
- `flutter test` *(fails: analyzer ^6.11.0 requires _macros 0.3.3)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1d587ecc8321b894d5845facb54a