### PR TITLE
Refresh macro goals on app resume and startup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,6 +25,7 @@ import 'package:opennutritracker/generated/l10n.dart';
 import 'package:opennutritracker/features/recipe/recipe_page.dart';
 import 'package:opennutritracker/features/auth/login_screen.dart';
 import 'package:opennutritracker/features/auth/reset_password_screen.dart';
+import 'package:opennutritracker/services/lifecycle_service.dart';
 import 'package:provider/provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -52,8 +53,8 @@ Future<void> main() async {
   const isUserInitialized = true;
   final hasAuthSession = Supabase.instance.client.auth.currentSession != null;
   final configRepo = locator<ConfigRepository>();
-  final hasAcceptedAnonymousData =
-      await configRepo.getConfigHasAcceptedAnonymousData();
+  final hasAcceptedAnonymousData = await configRepo
+      .getConfigHasAcceptedAnonymousData();
   final savedAppTheme = await configRepo.getConfigAppTheme();
   final log = Logger('main');
 
@@ -64,6 +65,8 @@ Future<void> main() async {
   log.info(
     'Starting App with Crashlytics ${hasAcceptedAnonymousData ? 'enabled' : 'disabled'} ...',
   );
+
+  await LifecycleService.instance().init();
   runAppWithChangeNotifiers(isUserInitialized, hasAuthSession, savedAppTheme);
 }
 
@@ -71,16 +74,15 @@ void runAppWithChangeNotifiers(
   bool userInitialized,
   bool hasAuthSession,
   AppThemeEntity savedAppTheme,
-) =>
-    runApp(
-      ChangeNotifierProvider(
-        create: (_) => ThemeModeProvider(appTheme: savedAppTheme),
-        child: AtlasTrackerApp(
-          userInitialized: userInitialized,
-          hasAuthSession: hasAuthSession,
-        ),
-      ),
-    );
+) => runApp(
+  ChangeNotifierProvider(
+    create: (_) => ThemeModeProvider(appTheme: savedAppTheme),
+    child: AtlasTrackerApp(
+      userInitialized: userInitialized,
+      hasAuthSession: hasAuthSession,
+    ),
+  ),
+);
 
 class AtlasTrackerApp extends StatelessWidget {
   final bool userInitialized;

--- a/lib/services/lifecycle_service.dart
+++ b/lib/services/lifecycle_service.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/widgets.dart';
+import 'package:logging/logging.dart';
+import 'package:opennutritracker/services/firebase_messaging_service.dart';
+
+/// Observes the application lifecycle to refresh macro goals when returning
+/// to the foreground or on cold start.
+class LifecycleService with WidgetsBindingObserver {
+  LifecycleService._internal();
+  static final LifecycleService _instance = LifecycleService._internal();
+  factory LifecycleService.instance() => _instance;
+
+  final Logger _log = Logger('LifecycleService');
+
+  /// Initializes the service and performs an initial refresh if needed.
+  Future<void> init() async {
+    WidgetsBinding.instance.addObserver(this);
+    _log.fine('[🚀] LifecycleService initialized');
+    await FirebaseMessagingService.instance().refreshMacroGoalsIfStudent();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _log.fine('[🔄] App resumed, refreshing macro goals');
+      FirebaseMessagingService.instance().refreshMacroGoalsIfStudent();
+    }
+  }
+
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+  }
+}


### PR DESCRIPTION
## Summary
- add LifecycleService observing app lifecycle to refresh macro goals
- centralize macro refresh in FirebaseMessagingService
- trigger lifecycle service at startup so students receive updates on resume

## Testing
- `flutter pub get` *(fails: analyzer ^6.11.0 requires _macros 0.3.3 from sdk)*
- `flutter analyze` *(fails: analyzer ^6.11.0 requires _macros 0.3.3 from sdk)*
- `flutter test` *(fails: analyzer ^6.11.0 requires _macros 0.3.3 from sdk)*


------
https://chatgpt.com/codex/tasks/task_e_68af6627424c8321b1147518eda81213